### PR TITLE
Fix bug in RNN where hprev always referred to start. 

### DIFF
--- a/makemore.py
+++ b/makemore.py
@@ -330,6 +330,7 @@ class RNN(nn.Module):
         for i in range(t):
             xt = emb[:, i, :] # (b, n_embd)
             ht = self.cell(xt, hprev) # (b, n_embd2)
+            hprev = ht
             hiddens.append(ht)
 
         # decode the outputs


### PR DESCRIPTION
Change so that `hprev` refers to output of previous cell.

As a sanity check, I ran the code with and without the fix and compared it to the Bigram baseline model.

`python makemore.py -i names.txt -o names --max-steps=10000 --type=rnn`

![fixed_rnn_makemore](https://user-images.githubusercontent.com/1936421/190378303-59c78f1b-56c6-41cf-87c4-c11e8a8d24c4.png)
